### PR TITLE
Updates build script & fixes computation of number of baselines

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,47 +1,41 @@
 #!/bin/bash -e
 
 # First, you need to source the bash library
-module load bash-utils
+module load bash-utils 
 source "${BASH_UTILS_DIR}/build_utils.sh"
 
 get_commit_hash
 
-PROGRAM_NAME=blink_preprocessing
+PROGRAM_NAME=blink-preprocessing 
 PROGRAM_VERSION=main #master #${COMMIT_HASH:0:7}
 
  
-# the following function sets up the installation path according to the
-# cluster the script is running on and the first argument given. The argument
-# can be:
-# - "group": install the software in the group wide directory
-# - "user": install the software only for the current user
-# - "test": install the software in the current working directory 
-process_build_script_input group # user
+# the following function sets up the installation path according to the cluster the script is running on and the first argument given. The argument can be: - "group": install the software in the group wide directory - "user": install the software only for the current user - "test": install the software in the current working directory
+process_build_script_input user
 
 
-# load all the modules required for the program to compile and run.
-# the following command also adds those module names in the modulefile
-# that this script will generate.
-echo "Loading required modules ..."
-module reset
-module_load  blink_test_data/devel blink_astroio/master rocm/5.7.3
+# load all the modules required for the program to compile and run. the following command also adds those module names in the modulefile that this script will generate.
+echo "Loading required modules ..." 
+
+module reset 
+module_load blink_test_data/devel blink-astroio/master rocm/6.4.1
 
 # cmake is only required at build time, so we use the normal module load
-module load cmake/3.27.7
+module load cmake/3.30.5
 # build your software..
 echo "Building the software.."
 
-[ -d build ] || mkdir build
-cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DCMAKE_CXX_COMPILER=hipcc -DCMAKE_C_COMPILER=hipcc -DCMAKE_BUILD_TYPE=RelWithDebugInfo #Release
+[ -d build ] || mkdir build 
+cd build 
+cmake .. -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DCMAKE_CXX_COMPILER=hipcc -DCMAKE_C_COMPILER=hipcc -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS=-O0 #Release 
 make VERBOSE=1
 
 # Install the software
-make test
+make test 
 make install
 
 
-echo "Creating the modulefile.."
+echo "Creating the modulefile.." 
 create_modulefile
 
 echo "Done."

--- a/src/calibration.cpp
+++ b/src/calibration.cpp
@@ -55,7 +55,7 @@ void apply_solutions_cpu(Visibilities &vis, const CalibrationSolutions& sol, uns
     else
         channelRatio =  vis.nFrequencies / n_solfreq_per_band;
 
-    const unsigned int n_baselines {(vis.obsInfo.nAntennas + 1) * (vis.obsInfo.nAntennas / 2)};
+    const unsigned int n_baselines {((vis.obsInfo.nAntennas + 1) * vis.obsInfo.nAntennas) / 2};
     const size_t matrix_size {n_baselines * vis.obsInfo.nPolarizations * vis.obsInfo.nPolarizations * 2};
     const size_t n_interval_values {matrix_size * vis.nFrequencies};
 
@@ -74,6 +74,7 @@ void apply_solutions_cpu(Visibilities &vis, const CalibrationSolutions& sol, uns
                 unsigned int a2 {baseline - ((a1 + 1) * a1)/2};
                 const JonesMatrix<double> &solA = sol.data()[a1 * sol.header.channel_count + solChannel];
                 const JonesMatrix<double> &solB = sol.data()[a2 * sol.header.channel_count + solChannel];
+                if(solA.isnan() || solB.isnan()) continue;
                 float *data {reinterpret_cast<float*>(vis.data()) + nInterval * n_interval_values + matrix_size * ch + 8 * baseline};
                 
                 JonesMatrix<double> visData {JonesMatrix<double>::from_array<double, float>(data)};

--- a/src/calibration_gpu.cpp
+++ b/src/calibration_gpu.cpp
@@ -7,7 +7,7 @@ __global__ void apply_solutions_kernel(float* vis, ObservationInfo obsInfo, cons
 
     const unsigned int n_solfreq_per_band = sol_header.channel_count / 24u;
     const unsigned int solutions_offset = coarse_channel_index * n_solfreq_per_band;
-    const unsigned int n_baselines {(obsInfo.nAntennas + 1) * (obsInfo.nAntennas / 2)};
+    const unsigned int n_baselines {((obsInfo.nAntennas + 1) * obsInfo.nAntennas) / 2};
     const size_t matrix_size {n_baselines * obsInfo.nPolarizations * obsInfo.nPolarizations * 2};
     const unsigned int n_channels {gridDim.y};
     const size_t n_interval_values {matrix_size * n_channels};
@@ -31,6 +31,7 @@ __global__ void apply_solutions_kernel(float* vis, ObservationInfo obsInfo, cons
         unsigned int a2 {baseline - ((a1 + 1) * a1)/2};
         const JonesMatrix<double> &solA = sol[a1 * sol_header.channel_count + solChannel];
         const JonesMatrix<double> &solB = sol[a2 * sol_header.channel_count + solChannel];
+        if(solA.isnan() || solB.isnan()) continue;
         float *data {vis + interval * n_interval_values + matrix_size * ch + 8 * baseline};
         
         JonesMatrix<double> visData {JonesMatrix<double>::from_array<double, float>(data)};


### PR DESCRIPTION
- Updates build script with latest versions of modules.
- Fixed the way I compute the number of baselines, as in other projects.
- Changed data type in some parts of the code to make it uniform across the codebase. I will probably need to go back here and see if we need to use 64 bit types such as `size_t` or `unsigned long long`.